### PR TITLE
FIX rotate in chrome

### DIFF
--- a/herana/static/javascript/graph.js
+++ b/herana/static/javascript/graph.js
@@ -22,7 +22,8 @@ var Graph = function() {
     self.svg = d3.select("#graph")
       .append("svg")
       .attr("width", self.w)
-      .attr("height", self.h);
+      .attr("height", self.h)
+      .append("g");
 
     self.populateInstituteFilter()
     self.units = self.getLevelUnits()


### PR DESCRIPTION
It looks like chrome doesn't like doing a transform on the top level SVG
element. So apply it to a <g> element instead.

@xybrnet 
